### PR TITLE
refactor for new official tomcat docker distro mode. corretto added.

### DIFF
--- a/magnolia-base/corretto/Dockerfile
+++ b/magnolia-base/corretto/Dockerfile
@@ -1,0 +1,13 @@
+ARG TOMCAT_VER
+ARG JRE_VER
+
+FROM tomcat:${TOMCAT_VER}-${JRE_VER}
+
+MAINTAINER Magnolia SRE Team "https://github.com/magnolia-sre"
+
+ONBUILD COPY files/setenv.sh $CATALINA_HOME/bin/
+
+RUN yum install -y wget && \
+    rm -Rf $CATALINA_HOME/webapps/* 
+
+VOLUME /var/lib/magnolia

--- a/magnolia-base/corretto/args.csv
+++ b/magnolia-base/corretto/args.csv
@@ -1,3 +1,4 @@
 # Tomcat Version,JDK Version
+9.0.24,jdk8-corretto
 9.0.24,jdk11-corretto
 #end

--- a/magnolia-base/corretto/args.csv
+++ b/magnolia-base/corretto/args.csv
@@ -1,3 +1,3 @@
 # Tomcat Version,JDK Version
-8.5.35,jre8
+9.0.24,jdk11-corretto
 #end

--- a/magnolia-base/corretto/build.sh
+++ b/magnolia-base/corretto/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+docker build --build-arg TOMCAT_VER=$1  \
+             --build-arg JRE_VER=$2  \
+             --tag magnolia/magnolia-base:$1-$2 .
+

--- a/magnolia-base/corretto/push.sh
+++ b/magnolia-base/corretto/push.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker push magnolia/magnolia-base:$1-$2

--- a/magnolia-base/default/Dockerfile
+++ b/magnolia-base/default/Dockerfile
@@ -1,0 +1,13 @@
+ARG TOMCAT_VER
+ARG JRE_VER
+
+FROM tomcat:${TOMCAT_VER}-${JRE_VER}
+
+MAINTAINER Magnolia SRE Team "https://github.com/magnolia-sre"
+
+ONBUILD COPY files/setenv.sh $CATALINA_HOME/bin/
+
+RUN apt-get update && apt-get install -y wget && \
+    rm -Rf $CATALINA_HOME/webapps/* 
+
+VOLUME /var/lib/magnolia

--- a/magnolia-base/default/args.csv
+++ b/magnolia-base/default/args.csv
@@ -1,3 +1,4 @@
 # Tomcat Version,JDK Version
 8.5.35,jre8
+9.0.24,jdk11-openjdk
 #end

--- a/magnolia-base/default/build.sh
+++ b/magnolia-base/default/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+docker build --build-arg TOMCAT_VER=$1  \
+             --build-arg JRE_VER=$2  \
+             --tag magnolia/magnolia-base:$1-$2 .
+

--- a/magnolia-base/default/push.sh
+++ b/magnolia-base/default/push.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker push magnolia/magnolia-base:$1-$2

--- a/magnolia-base/slim/args.csv
+++ b/magnolia-base/slim/args.csv
@@ -1,4 +1,5 @@
-# Tomcat Version , JDK Version
-  8.5.35         , jre8       
-  9.0.13         , jre11       
+# Tomcat Version,JDK Version
+8.5.35,jre8
+9.0.13,jre11
+9.0.24,jdk11-openjdk
 #end

--- a/magnolia-ce-pgsql/Dockerfile
+++ b/magnolia-ce-pgsql/Dockerfile
@@ -2,7 +2,7 @@ ARG TOMCAT_VER
 ARG JRE_VER
 ARG DIST
 
-FROM magnolia/magnolia-base:${TOMCAT_VER}-${JRE_VER}-${DIST}
+FROM magnolia/magnolia-base:${TOMCAT_VER}-${JRE_VER}${DIST:+-$DIST}
 
 ARG MGNL_VER
 ENV POSTGRESQL_VER 42.2.5

--- a/magnolia-ce-pgsql/args.csv
+++ b/magnolia-ce-pgsql/args.csv
@@ -1,4 +1,6 @@
-# Magnolia Version, Tomcat Version , JDK Version, Distribution
-  5.7.1           , 8.5.35         , jre8       , alpine
-  6.0             , 9.0.13         , jre11      , slim 
+# Magnolia Version,Tomcat Version,JDK Version,Distribution
+5.7.1,8.5.35,jre8,alpine
+6.1.2,9.0.24,jdk11-openjdk
+6.0,9.0.13,jre11,slim
+6.1.2,9.0.24,jdk11-openjdk,slim
 #end

--- a/magnolia-ce-pgsql/build.sh
+++ b/magnolia-ce-pgsql/build.sh
@@ -2,5 +2,5 @@
 docker build --build-arg MGNL_VER=$1  \
 			 --build-arg TOMCAT_VER=$2  \
              --build-arg JRE_VER=$3  \
-             --build-arg DIST=$4  \
-             --tag magnolia/magnolia-ce-pgsql:$1-$2-$3-$4 .
+             --build-arg DIST=${4:+$4}  \
+             --tag magnolia/magnolia-ce-pgsql:$1-$2-$3-${4:+$4} .

--- a/magnolia-ce-pgsql/docker-compose.yml
+++ b/magnolia-ce-pgsql/docker-compose.yml
@@ -3,23 +3,25 @@ version: '3'
 services:
 
   dbAuthor:
-    image: postgres
+    image: postgres:42.2.5
     environment:
       - POSTGRES_USER=magnolia
       - POSTGRES_PASSWORD=mysecretpassword
 
   dbPublic:
-    image: postgres
+    image: postgres:42.2.5
     environment:
       - POSTGRES_USER=magnolia
       - POSTGRES_PASSWORD=mysecretpassword
 
   author:
-    image: magnolia/magnolia-ce-pgsql:6.0-9.0.13-jre11-slim
+    image: magnolia/magnolia-ce-pgsql:6.1.2-9.0.24-jdk11-openjdk-slim
     ports:
       - "3000:8080"
     links:
       - dbAuthor:db
+    depends_on:
+      - dbAuthor
     environment:
       - INSTANCE_TYPE=author
       - DB_ADDRESS=db
@@ -31,11 +33,13 @@ services:
       - DEVELOP_MODE=false
 
   public:
-    image: magnolia/magnolia-ce-pgsql:6.0-9.0.13-jre11-slim
+    image: magnolia/magnolia-ce-pgsql:6.1.2-9.0.24-jdk11-openjdk-slim
     ports:
       - "3001:8080"
     links:
       - dbPublic:db
+    depends_on:
+      - dbPublic
     environment:
       - INSTANCE_TYPE=public
       - DB_ADDRESS=db

--- a/magnolia-ce-pgsql/push.sh
+++ b/magnolia-ce-pgsql/push.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-docker push magnolia/magnolia-ce-pgsql:$1-$2-$3-$4 
+docker push magnolia/magnolia-ce-pgsql:$1-$2-$3${4:+-$4}
 

--- a/magnolia-ce/Dockerfile
+++ b/magnolia-ce/Dockerfile
@@ -2,7 +2,7 @@ ARG TOMCAT_VER
 ARG JRE_VER
 ARG DIST
 
-FROM magnolia/magnolia-base:${TOMCAT_VER}-${JRE_VER}-${DIST}
+FROM magnolia/magnolia-base:${TOMCAT_VER}-${JRE_VER}${DIST:+-$DIST}
 
 ARG MGNL_VER
 

--- a/magnolia-ce/args.csv
+++ b/magnolia-ce/args.csv
@@ -1,5 +1,8 @@
 # Magnolia Version,Tomcat Version,JDK Version,Distribution
 5.7.1,8.5.35,jre8,alpine
+5.7.4,9.0.24,jre8,alpine
+5.7.4,9.0.24,jre11,slim
+5.7.4,9.0.24,jdk11-corretto
 6.0,9.0.13,jre11,slim
 6.1.2,9.0.24,jdk11-openjdk,slim
 6.1.2,9.0.24,jdk11-corretto

--- a/magnolia-ce/args.csv
+++ b/magnolia-ce/args.csv
@@ -1,4 +1,6 @@
-# Magnolia Version, Tomcat Version , JDK Version, Distribution
-  5.7.1           , 8.5.35         , jre8       , alpine
-  6.0             , 9.0.13         , jre11      , slim 
+# Magnolia Version,Tomcat Version,JDK Version,Distribution
+5.7.1,8.5.35,jre8,alpine
+6.0,9.0.13,jre11,slim
+6.1.2,9.0.24,jdk11-openjdk,slim
+6.1.2,9.0.24,jdk11-corretto
 #end

--- a/magnolia-ce/build.sh
+++ b/magnolia-ce/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+
 docker build --build-arg MGNL_VER=$1  \
 			 --build-arg TOMCAT_VER=$2  \
              --build-arg JRE_VER=$3  \
-             --build-arg DIST=$4  \
-             --tag magnolia/magnolia-ce:$1-$2-$3-$4 .
+             --build-arg DIST=${4:+$4}  \
+             --tag magnolia/magnolia-ce:$1-$2-$3${4:+-$4} .

--- a/magnolia-ce/push.sh
+++ b/magnolia-ce/push.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-docker push magnolia/magnolia-ce:$1-$2-$3-$4 
+docker push magnolia/magnolia-ce:$1-$2-$3${4:+-$4} 
 


### PR DESCRIPTION
Official tomcat latest docker distro (9.0.24) changed a bit. OS distro is actually optional. "alpine" is actually used for default openjdk images. The only distro variation by official tomcat is for "-slim". Another choice is "corretto" which officially comes from amazon with no variations (OS image is amazon's centos custom distribution).
In other words:
- "alpine" should be **deprecated** (there are no more images combination available from tomcat)
- "default" in _magnolia-base_ stands for "openjdk" distribution. it's the tomcat's default.
- "slim" in _magnolia-base_ stands for "openjdk with slim flavour". it's the only tomcat official accepted variation
- "corretto" is not an OS distro because amazon has only its default one

Doing this refactoring, "dist" param has been made totally optional. This way, mapping (and generate) other "flavours" should be more flexible.
Noteworthy: tomcat 9.0.24 and magnolia 6.1.2 has been introduced.