### PR TITLE
Fix incorrect apiVersion and syntax of Ingress resource for newer K8S…

### DIFF
--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "magnolia.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -26,14 +26,20 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}-author
-              servicePort: http-author
+              service:
+                name: {{ $fullName }}-author
+                port:
+                  name: http-author
     - host: {{ .Values.ingress.publicHost }}
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}-public
-              servicePort: http-public
+              service:
+                name: {{ $fullName }}-public
+                port:
+                  name: http-public
 {{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -90,12 +90,12 @@ readiness:
 # https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#using-a-feature
 # https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment#startup_probe
 # TODO: enable this on the cluster and tighten the liveness probe!
-startupProbe: {}
-#  httpGet:
-#    path: /.rest/status
-#    port: http
-#  failureThreshold: 30
-#  periodSeconds: 6
+startupProbe: 
+  httpGet:
+    path: /.rest/status
+    port: http
+  failureThreshold: 30
+  periodSeconds: 6
 
 env:
   author:


### PR DESCRIPTION
I couldn't deploy this on a recent version of Minikube because of the apiVersion of the Ingress resource.

In my case, on K8S version 1.24.1 the Ingress resource manifest does not work correctly.

It's fixed following what is described in https://stackoverflow.com/a/70855124/6939011